### PR TITLE
Fix to correct the incorrect syntax of output JSON files.

### DIFF
--- a/instalremote.py
+++ b/instalremote.py
@@ -132,10 +132,10 @@ def get_json_for(model_id,grounding_id,query_id,answer_set_id):
     assert (response.status_code == 200)
     return response.json()
 
-def dump_json_to_file(json,filename):
+def dump_json_to_file(json_data,filename):
     with open(filename,"wt") as f:
         print("Saving json in file {}...".format(filename))
-        print(json,file=f)
+        json.dump(json_data,f)
 
 if __name__ == "__main__":
     instal_remote()


### PR DESCRIPTION
- JSON standard defines the name within a name/object pair as a string. 
- JSON standard defines it as a string is enclosed in a quotation marks. 
- The current method of writing out to json file it outputs in single quotes.

Contents of pull request should fix this issue, by using the simple json library to write to file instead of using the python print function.